### PR TITLE
Update 00-setup_data.R to switch `length` for `nrow`

### DIFF
--- a/R/00-setup_data.R
+++ b/R/00-setup_data.R
@@ -62,7 +62,7 @@ setup_data <- function(counts = NULL,
   if (nrow(pg_ids) != nrow(counts)) stop("the number of rows in the pg_info is not equal to the number of rows in the counts")
 
   # we need the first column to be a unique id
-  if (!(nrow(unique(pg_ids[, 1])) == nrow(pg_ids[, 1]))) stop("The paired guide IDs must be a unique ID")
+  if (!(length(unique(pg_ids[, 1])) == length(pg_ids[, 1]))) stop("The paired guide IDs must be a unique ID")
   new_data$metadata$pg_ids <- pg_ids
 
   # Store the raw counts


### PR DESCRIPTION
I think the `nrow` functions are leading to NULLs and the `length` should work. Tested on my local.

In response to new problem on #28 