### PR TITLE
Add ability to select columns for the zerocount filter

### DIFF
--- a/R/02-filter.R
+++ b/R/02-filter.R
@@ -58,7 +58,9 @@ qc_filter_zerocounts <- function(gimap_dataset, filter_zerocount_target_col = NU
 
   if (is.null(filter_zerocount_target_col)) {filter_zerocount_target_col <- c(1:ncol(gimap_dataset$raw_counts))}
 
-  #@Howard please help: should set up a check that if filter_zerocount_target_col is not null, it's an R vector (? -- the c() thing) of integers greater than or equal to 1 and less than or equal to number of possible columns in data
+if (!all(filter_zerocount_target_col %in% 1:ncol(gimap_dataset$raw_counts))) {
+    stop("The columns selected do not exist. `filter_zerocount_target_col` needs to correspond to the index of the columns in `gimap_dataset$raw_counts` that you need to filter by") 
+   }
   
   counts_filter <- data.frame(gimap_dataset$raw_counts[,filter_zerocount_target_col]) %>% map(~.x %in% c(0)) %>% reduce(`|`)
 

--- a/R/02-filter.R
+++ b/R/02-filter.R
@@ -48,6 +48,9 @@ gimap_filter <- function(.data = NULL,
 #' @examples \dontrun{
 #'   gimap_dataset <- get_example_data("gimap")
 #'   qc_filter_zerocounts(gimap_dataset)
+#'   
+#'   #or to specify a different column (or set of columns to select)
+#'   qc_filter_zerocount(gimap_dataset, filter_zerocount_target_col = c(1,2))
 #' }
 #'
 

--- a/R/02-filter.R
+++ b/R/02-filter.R
@@ -58,7 +58,7 @@ qc_filter_zerocounts <- function(gimap_dataset, filter_zerocount_target_col = NU
 
   if (is.null(filter_zerocount_target_col)) {filter_zerocount_target_col <- c(1:ncol(gimap_dataset$raw_counts))}
 
-if (!all(filter_zerocount_target_col %in% 1:ncol(gimap_dataset$raw_counts))) {
+  if (!all(filter_zerocount_target_col %in% 1:ncol(gimap_dataset$raw_counts))) {
     stop("The columns selected do not exist. `filter_zerocount_target_col` needs to correspond to the index of the columns in `gimap_dataset$raw_counts` that you need to filter by") 
    }
   
@@ -102,7 +102,9 @@ qc_filter_plasmid <- function(gimap_dataset, cutoff = NULL, filter_plasmid_targe
   
   if (is.null(filter_plasmid_target_col)) {filter_plasmid_target_col <- c(1)}
   
-  #@Howard please help: should set up a check that if filter_plasmid_target_col is not null, it's an R vector (? -- the c() thing) of integers greater than or equal to 1 and less than or equal to number of possible columns in data
+  if (!all(filter_plasmid_target_col %in% 1:ncol(gimap_dataset$transformed_data$log2_cpm))) {
+    stop("The columns selected do not exist. `filter_plasmid_target_col` needs to correspond to the index of the columns in `gimap_dataset$transformed_data$log2_cpm` that you need to filter by") 
+  }
   
   plasmid_data <- data.frame(gimap_dataset$transformed_data$log2_cpm[, filter_plasmid_target_col]) %>% `colnames<-`(rep(c("plasmid_log2_cpm"), length(filter_plasmid_target_col))) %>% clean_names()
   

--- a/R/plots-qc.R
+++ b/R/plots-qc.R
@@ -121,7 +121,7 @@ qc_constructs_countzero_bar <- function(gimap_dataset, wide_ar = 0.75){
   qc_filter_output <- qc_filter_zerocounts(gimap_dataset)
 
   return(
-    example_counts[qc_filter_output$filter, c(3:5)] %>%
+    gimap_dataset$raw_counts[qc_filter_output$filter, c(3:5)] %>%
       as.data.frame() %>%
       mutate(row = row_number()) %>%
       tidyr::pivot_longer(tidyr::unite(gimap_dataset$metadata$sample_metadata[c(3:5), c("day", "rep")], "colName")$colName,
@@ -204,6 +204,10 @@ qc_cor_heatmap <- function(gimap_dataset) {
 qc_plasmid_histogram <- function(gimap_dataset, cutoff = NULL, filter_plasmid_target_col = NULL, wide_ar = 0.75) {
   
   if (is.null(filter_plasmid_target_col)) {filter_plasmid_target_col <- c(1)}
+  
+  if (!all(filter_plasmid_target_col %in% 1:ncol(gimap_dataset$transformed_data$log2_cpm))) {
+    stop("The columns selected do not exist. `filter_plasmid_target_col` needs to correspond to the index of the columns in `gimap_dataset$transformed_data$log2_cpm` that you need to filter by") 
+  }
   
   to_plot <- data.frame(gimap_dataset$transformed_data$log2_cpm[, filter_plasmid_target_col]) %>% `colnames<-`(rep(c("plasmid_log2_cpm"), length(filter_plasmid_target_col))) %>% clean_names()
   

--- a/inst/rmd/gimapQCTemplate.Rmd
+++ b/inst/rmd/gimapQCTemplate.Rmd
@@ -81,7 +81,7 @@ qc_constructs_countzero_bar(gimap_dataset)
 If this filter is applied, this is the number of pgRNAs that would be filtered out
 
 ```{r}
-qc_filter_zerocounts(gimap_dataset, filter_zerocount_target_col)$reportdf
+qc_filter_zerocounts(gimap_dataset, filter_zerocount_target_col = filter_zerocount_target_col)$reportdf
 ```
 
 ### Filter pgRNAs where there is a low log2 CPM value for the plasmid sample/time point

--- a/inst/rmd/gimapQCTemplate.Rmd
+++ b/inst/rmd/gimapQCTemplate.Rmd
@@ -81,7 +81,7 @@ qc_constructs_countzero_bar(gimap_dataset)
 If this filter is applied, this is the number of pgRNAs that would be filtered out
 
 ```{r}
-qc_filter_zerocounts(gimap_dataset)$reportdf
+qc_filter_zerocounts(gimap_dataset, filter_zerocount_target_col)$reportdf
 ```
 
 ### Filter pgRNAs where there is a low log2 CPM value for the plasmid sample/time point


### PR DESCRIPTION
:warning: This is a stacked PR based on #35 :warning: (edit: but now that #35 is merged, I've changed the base to main)

This PR adds in a parameter/functionality to select columns for the zerocount filter. By default, the filter will select all data columns. However, it provides the user with the ability to tweak which columns are used. 

I've notated in the code for both this function (and the plasmid filter function) that we could use a test in case the user supplies something to check that the user supplied target columns following the conventions we want: e.g., R vector (the `c()` thing -- edit(based on code review for #35, not sure it has to be the c() thing, just in some way a collection of integers like `1:2`. Do we want them to be consecutive numbers?)) and are integers greater than or equal to 1 and less than or equal to the number of columns. @howardbaek can you add those or check what I add if you prefer I do the adding.

Next PR will fill in the 3rd filter/target col selection parameter discussed in PR #35.