### PR TITLE
Add ability to select columns for the last sample replicates

### DIFF
--- a/R/02-filter.R
+++ b/R/02-filter.R
@@ -50,7 +50,7 @@ gimap_filter <- function(.data = NULL,
 #'   qc_filter_zerocounts(gimap_dataset)
 #'   
 #'   #or to specify a different column (or set of columns to select)
-#'   qc_filter_zerocount(gimap_dataset, filter_zerocount_target_col = c(1,2))
+#'   qc_filter_zerocount(gimap_dataset, filter_zerocount_target_col = 1:2)
 #' }
 #'
 
@@ -93,7 +93,7 @@ qc_filter_zerocounts <- function(gimap_dataset, filter_zerocount_target_col = NU
 #'   qc_filter_plasmid(gimap_dataset, filter_plasmid_target_col = 1:2)
 #'
 #'   # or to specify a cutoff value that will be used in the filter rather than the lower outlier default as well as to specify a different column (or set of columns) to select
-#'   qc_filter_plasmid(gimap_dataset, cutoff=1.75, filter_plasmid_target_col=c(1,2))
+#'   qc_filter_plasmid(gimap_dataset, cutoff=1.75, filter_plasmid_target_col=1:2)
 #' 
 #' }
 #'

--- a/R/plots-qc.R
+++ b/R/plots-qc.R
@@ -136,9 +136,17 @@ qc_constructs_countzero_bar <- function(gimap_dataset, filter_zerocount_target_c
 
   if(is.null(filter_zerocount_target_col)){filter_zerocount_target_col <- c(1:ncol(gimap_dataset$raw_counts))}
   
+  if (!all(filter_zerocount_target_col %in% 1:ncol(gimap_dataset$raw_counts))) {
+    stop("The columns selected do not exist. `filter_zerocount_target_col` needs to correspond to the index of the columns in `gimap_dataset$raw_counts` that you need to filter by") 
+  }
+  
   qc_filter_output <- qc_filter_zerocounts(gimap_dataset, filter_zerocount_target_col = filter_zerocount_target_col)
   
   if(is.null(filter_replicates_target_col)){ filter_replicates_target_col <- c((ncol(gimap_dataset$transformed_data$log2_cpm)-2) : ncol(gimap_dataset$transformed_data$log2_cpm))} #last 3 columns of the data
+  
+  if (!all(filter_replicates_target_col %in% 1:ncol(gimap_dataset$transformed_data$log2_cpm))) {
+    stop("The columns selected do not exist. `filter_replicates_target_col` needs to correspond to the index of the columns in `gimap_dataset$transformed_data$log2_cpm` that you need to filter by") 
+  }
   
 
   return(

--- a/R/plots-qc.R
+++ b/R/plots-qc.R
@@ -122,13 +122,13 @@ qc_variance_hist <- function(gimap_dataset, filter_replicates_target_col = NULL,
 #' qc_constructs_countzero_bar(gimap_dataset)
 #' 
 #' #or if you want to select a specific column(s) for looking at where/which samples zero counts are present for
-#' qc_constructs_countzero_bar(gimap_dataset, filter_zerocount_target_col = c(3:5))
+#' qc_constructs_countzero_bar(gimap_dataset, filter_zerocount_target_col = 3:5)
 #' 
 #' #or if you want to select a specific column(s) for the final day/sample replicates
-#' qc_constructs_countzero_bar(gimap_dataset, filter_replicates_target_col = c(3:5))
+#' qc_constructs_countzero_bar(gimap_dataset, filter_replicates_target_col = 3:5)
 #' 
 #' #or some combination of those
-#' qc_constructs_countzero_bar(gimap_dataset, filter_zerocount_target_col = c(3:5), filter_replicates_target_col = c(3:5))
+#' qc_constructs_countzero_bar(gimap_dataset, filter_zerocount_target_col = 3:5, filter_replicates_target_col = 3:5)
 #' }
 #'
 
@@ -215,10 +215,10 @@ qc_cor_heatmap <- function(gimap_dataset) {
 #' qc_plasmid_histogram(gimap_dataset, cutoff=1.75)
 #' 
 #' # or to specify a different column (or set of columns) to select
-#' qc_plasmid_histogram(gimap_dataset, filter_plasmid_target_col=c(1,2))
+#' qc_plasmid_histogram(gimap_dataset, filter_plasmid_target_col=1:2)
 #'
 #' # or to specify a "cutoff" value that will be displayed as a dashed vertical line as well as to specify a different column (or set of columns) to select
-#' qc_plasmid_histogram(gimap_dataset, cutoff=2, filter_plasmid_target_col=c(1,2))
+#' qc_plasmid_histogram(gimap_dataset, cutoff=2, filter_plasmid_target_col=1:2)
 #' }
 #'
 

--- a/R/plots-qc.R
+++ b/R/plots-qc.R
@@ -142,7 +142,7 @@ qc_constructs_countzero_bar <- function(gimap_dataset, filter_zerocount_target_c
   
 
   return(
-    example_counts[qc_filter_output$filter, filter_replicates_target_col] %>%
+    gimap_dataset$raw_counts[qc_filter_output$filter, filter_replicates_target_col] %>%
       as.data.frame() %>%
       mutate(row = row_number()) %>%
       tidyr::pivot_longer(tidyr::unite(gimap_dataset$metadata$sample_metadata[filter_replicates_target_col, c("day", "rep")], "colName")$colName,

--- a/inst/rmd/gimapQCTemplate.Rmd
+++ b/inst/rmd/gimapQCTemplate.Rmd
@@ -59,7 +59,7 @@ qc_cor_heatmap(gimap_dataset)
 ## Variance within replicates
 
 ```{r}
-qc_variance_hist(gimap_dataset)
+qc_variance_hist(gimap_dataset, filter_replicates_target_col = filter_replicates_target_col)
 ```
 
 ## Plasmid expression (log 2 cpm values for Day 0 sample/time point)
@@ -75,7 +75,7 @@ qc_plasmid_histogram(gimap_dataset)
 ### Replicates with a pgRNA count of 0 
 
 ```{r}
-qc_constructs_countzero_bar(gimap_dataset)
+qc_constructs_countzero_bar(gimap_dataset, filter_zerocount_target_col= filter_zerocount_target_col, filter_replicates_target_col = filter_replicates_target_col)
 ```
 
 If this filter is applied, this is the number of pgRNAs that would be filtered out


### PR DESCRIPTION
⚠️ This is a stacked PR based on PR #38 ⚠️ and should complete the described necessities/additions for 3 parameters as described in PR #35

This parameter for selecting columns doesn't directly impact a filter, but does impact two graphs. So there are only changes to the `R/plots-qc.R` file and the `inst/rmd/gimapQCTemplate.Rmd` file. Specifically impacting the `qc_variance_hist()` and 
 `qc_constructs_countzero_bar()` functions. The changes to these functions include adding to the headers (param and description information), replacing anywhere numbers are hardcoded with the parameter, and sets the parameters to a default if they're null. Within the QC Template Rmd, changes include referencing the parameters in the function calls.

I can confirm that I knit the `getting-started.Rmd` successfully locally. The only oddity is that the heatmap is still showing up in the vignette rather than the QC report (as mentioned in PR #33)  

Also need to setup something to check the identity of the target columns if they are not null as described in PR #38 