### PR TITLE
Beginning of making filtering steps all work together

### DIFF
--- a/R/02-filter.R
+++ b/R/02-filter.R
@@ -1,8 +1,11 @@
 #' A function to run filtering
-#' @description This is a function here's where we describe what it does
+#' @description This function applies filters to the gimap data. By default it runs both the zero count (across all samples) and the low plasmid cpm filters, but users can select a subset of these filters or even adjust the behavior of each filter
 #' @param .data Data can be piped in with %>% or |> from function to function. But the data must still be a gimap_dataset
 #' @param gimap_dataset A special dataset structure that is setup using the `setup_data()` function.
-#' @param filter_type Can be one of the following: `zero_count_only`, `low_plasmid_cpm_only` or `rep_variation`, `zero_in_last_time_point` or a vector that includes multiple of these filters.
+#' @param filter_type Can be one of the following: `zero_count_only`, `low_plasmid_cpm_only` or `both`. Potentially in the future also `rep_variation`, `zero_in_last_time_point` or a vector that includes multiple of these filters.
+#' @param filter_zerocount_target_col default is NULL; Which sample column(s) should be used to check for counts of 0? If NULL and not specified, downstream analysis will select all sample columns
+#' @param filter_plasmid_target_col default is NULL, and if NULL, will select the first column only; this parameter specifically should be used to specify the plasmid column(s) that will be selected
+#' @param cutoff default is NULL, relates to the low_plasmid_cpm filter; the cutoff for low log2 CPM values for the plasmid time period; if not specified, The lower outlier (defined by taking the difference of the lower quartile and 1.5 * interquartile range) is used
 #' You should decide on the appropriate filter based on the results of your QC report.
 #' @returns a filtered version of the gimap_dataset returned in the $filtered_data section
 #' @export
@@ -18,18 +21,41 @@
 #'
 #' # To see filtered data
 #' gimap_dataset$filtered_data
+#' 
+#' # If you want to only use a single filter or some subset, specify which using the filter_type parameter
+#' gimap_dataset <- gimap_filter(gimap_dataset, filter_type = "zero_count_only") 
+#' #or 
+#' gimap_dataset <- gimap_filter(gimap_dataset, filter_type = "low_plasmid_cpm_only")
+#' 
+#' # 
 #'
 #' }
 #'
 
 gimap_filter <- function(.data = NULL,
                          gimap_dataset,
-                         filter_type = "both") {
+                         filter_type = "both",
+                         cutoff = NULL,
+                         filter_zerocount_target_col = NULL,
+                         filter_plasmid_target_col = NULL) {
 
   if (!is.null(.data)) gimap_dataset <- .data
 
   if (!("gimap_dataset" %in% class(gimap_dataset))) stop("This function only works with gimap_dataset objects which can be made with the setup_data() function.")
-
+  
+  #check filter type input to make sure that it is a supportable input
+  if (!(filter_type %in% c("both", "zero_count_only", "low_plasmid_cpm_only"))) stop("Specification for `filter_type` not understood; Need to use 'both', 'zero_count_only', or 'low_plasmid_cpm_only'")
+  
+  if (filter_type == "both"){
+    zc_filter <- qc_filter_zerocounts(gimap_dataset, filter_zerocount_target_col = filter_zerocount_target_col)$filter
+    p_filter <- qc_filter_plasmid(gimap_dataset, cutoff = cutoff, filter_plasmid_target_col = filter_plasmid_target_col)
+    combined_filter <- combine_filters() #add this function
+  } else if (filter_type == "zero_count_only"){
+    zc_filter <- qc_filter_zerocounts(gimap_dataset, filter_zerocount_target_col = filter_zerocount_target_col)$filter
+  } else if(filter_type == "low_plasmid_cpm_only"){
+    p_filter <- qc_filter_plasmid(gimap_dataset, cutoff = cutoff, filter_plasmid_target_col = filter_plasmid_target_col)
+  }
+  
   gimap_dataset$filtered <- NULL #TODO: Filtered version of the data can be stored here
 
   return(gimap_dataset)
@@ -73,6 +99,7 @@ qc_filter_zerocounts <- function(gimap_dataset, filter_zerocount_target_col = NU
 #' @description This function flags and reports which and how many pgRNAs have low log2 CPM values for the plasmid/Day 0 sample/time point. If more than one column is specified as the plasmid sample, 
 #' we pool all the replicate samples to find the lower outlier and flag constructs for which any plasmid replicate has a log2 CPM value below the cutoff
 #' @param gimap_dataset The special gimap_dataset from the `setup_data` function which contains the log2 CPM transformed data
+#' @param cutoff default is NULL, the cutoff for low log2 CPM values for the plasmid time period; if not specified, The lower outlier (defined by taking the difference of the lower quartile and 1.5 * interquartile range) is used
 #' @param filter_plasmid_target_col default is NULL, and if NULL, will select the first column only; this parameter specifically should be used to specify the plasmid column(s) that will be selected
 #' @importFrom magrittr %>%
 #' @importFrom dplyr mutate across if_any

--- a/R/utils.R
+++ b/R/utils.R
@@ -40,7 +40,7 @@ get_example_data <- function(which_data) {
     )
     return(readr::read_tsv(file, show_col_types = FALSE))
   } else {
-    stop("Specification for `which_data` not understood; Need to use 'gimap', count', 'meta', or 'annotation' ")
+    stop("Specification for `which_data` not understood; Need to use 'gimap', 'count', 'meta', or 'annotation' ")
   }
 }
 


### PR DESCRIPTION
Sorry, this PR is the first step of filtering where the `filter_ki` branch builds on the `filter_qc_ki5` branch. PR #40 is trying to merge `filter_ki2` into `filter_ki`. I submitted those PRs out of order since this one will be PR #41. 

This PR makes a lot of documentation changes, explaining parameters and how to use the `gimap_filter()` function. 

It also builds the groundwork for the filters working together. 
* All supported/possible filters are first set to be NULL and then based on user input for which filter(s) to run, these variables are overwritten/remain NULL. 
* A list of all possible filters is built, and then we use the `reduce()` function to `cbind` these filters together. This approach ignores NULLs and returns a df with column(s) of TRUEs and FALSEs. 
* Then the `min_n_filters` parameter is used together with `rowSums` to find out which pgRNA constructs are flagged by at least that minimum number of filters that would result in the pgRNA constructs being removed from the dataset -- creating a consensus or combined filter.