### PR TITLE
start recording extra info on pg IDs

### DIFF
--- a/R/00-setup_data.R
+++ b/R/00-setup_data.R
@@ -33,14 +33,14 @@ setup_data <- function(counts = NULL,
     ),
     metadata = list(
       pg_ids = NULL,
-      pg_metadata = NULL,
       sample_metadata = NULL
     ),
     filtered_data = list(
       filter_step_run = FALSE, #adding a way to know if the filter step was run since it's optional
       metadata_pg_ids = NULL,
-      pg_metadata = NULL,
-      transformed_log2_cpm = NULL
+      transformed_log2_cpm = NULL,
+      removed_pg_ids = NULL,
+      all_reps_zerocount_ids = NULL
     ),
     annotation = NULL,
     log_fc = NULL,

--- a/R/02-filter.R
+++ b/R/02-filter.R
@@ -103,7 +103,7 @@ gimap_filter <- function(.data = NULL,
                                                         pivot_longer(starts_with("Filter"), #pivot longer so that IDs are repeated and filter names are listed in a column and the last column (`boolVals`) are TRUEs and FALSEs
                                                                      names_to = "filter_name", 
                                                                      values_to = "bool_vals") %>% 
-                                                        filter(boolVals == TRUE) %>% #drop rows where boolVals is false, so this leaves only filters that flagged a pgRNA for removal
+                                                        filter(bool_vals == TRUE) %>% #drop rows where boolVals is false, so this leaves only filters that flagged a pgRNA for removal
                                                         select(id, filterName) %>% #drop the boolVals column because don't need it anymore
                                                         group_by(id) %>% #group by the pgRNA constructs
                                                         summarize(relevantFilters = toString(filterName)) #and make a column that comma separates the relevant filters

--- a/R/02-filter.R
+++ b/R/02-filter.R
@@ -100,7 +100,7 @@ gimap_filter <- function(.data = NULL,
   
   ## save a list of which pgRNAs are filtered out once filtering is complete
   gimap_dataset$filtered_data$removed_pg_ids <- cbind(gimap_dataset$metadata$pg_ids[combined_filter,], one_filter_df[combined_filter,]) %>% #add the IDs as a column together with the TRUEs and FALSEs for each filter, focusing only on pgRNAs which are in some way flagged for removal
-                                                        pivot_longer(starts_with("Filter"), #pivot longer so that IDs are repeated and filter names are listed in a column and the last column (`boolVals`) are TRUEs and FALSEs
+                                                        pivot_longer(starts_with("filter_"), #pivot longer so that IDs are repeated and filter names are listed in a column and the last column (`boolVals`) are TRUEs and FALSEs
                                                                      names_to = "filter_name", 
                                                                      values_to = "bool_vals") %>% 
                                                         filter(bool_vals == TRUE) %>% #drop rows where boolVals is false, so this leaves only filters that flagged a pgRNA for removal

--- a/R/02-filter.R
+++ b/R/02-filter.R
@@ -102,7 +102,7 @@ gimap_filter <- function(.data = NULL,
   gimap_dataset$filtered_data$removed_pg_ids <- cbind(gimap_dataset$metadata$pg_ids[combined_filter,], one_filter_df[combined_filter,]) %>% #add the IDs as a column together with the TRUEs and FALSEs for each filter, focusing only on pgRNAs which are in some way flagged for removal
                                                         pivot_longer(starts_with("Filter"), #pivot longer so that IDs are repeated and filter names are listed in a column and the last column (`boolVals`) are TRUEs and FALSEs
                                                                      names_to = "filter_name", 
-                                                                     values_to = "boolVals") %>% 
+                                                                     values_to = "bool_vals") %>% 
                                                         filter(boolVals == TRUE) %>% #drop rows where boolVals is false, so this leaves only filters that flagged a pgRNA for removal
                                                         select(id, filterName) %>% #drop the boolVals column because don't need it anymore
                                                         group_by(id) %>% #group by the pgRNA constructs

--- a/R/02-filter.R
+++ b/R/02-filter.R
@@ -106,7 +106,7 @@ gimap_filter <- function(.data = NULL,
                                                         filter(boolVals == TRUE) %>% #drop rows where boolVals is false, so this leaves only filters that flagged a pgRNA for removal
                                                         select(id, filterName) %>% #drop the boolVals column because don't need it anymore
                                                         group_by(id) %>% #group by the pgRNA constructs
-                                                        summarize(relevantFilters = toString(filterName)), #and make a column that comma separates the relevant filters
+                                                        summarize(relevantFilters = toString(filterName)) #and make a column that comma separates the relevant filters
   
   ## save a list of which pgRNAs have a zero count in all final timepoint replicates. 
   #NOTE these are NOT necessarily filtered out

--- a/R/02-filter.R
+++ b/R/02-filter.R
@@ -104,7 +104,7 @@ gimap_filter <- function(.data = NULL,
                                                                      names_to = "filter_name", 
                                                                      values_to = "bool_vals") %>% 
                                                         filter(bool_vals == TRUE) %>% #drop rows where boolVals is false, so this leaves only filters that flagged a pgRNA for removal
-                                                        select(id, filterName) %>% #drop the boolVals column because don't need it anymore
+                                                        select(id, filter_name) %>% #drop the boolVals column because don't need it anymore
                                                         group_by(id) %>% #group by the pgRNA constructs
                                                         summarize(relevantFilters = toString(filterName)) #and make a column that comma separates the relevant filters
   

--- a/R/02-filter.R
+++ b/R/02-filter.R
@@ -5,12 +5,17 @@
 #' @param filter_type Can be one of the following: `zero_count_only`, `low_plasmid_cpm_only` or `both`. Potentially in the future also `rep_variation`, `zero_in_last_time_point` or a vector that includes multiple of these filters.
 #' @param filter_zerocount_target_col default is NULL; Which sample column(s) should be used to check for counts of 0? If NULL and not specified, downstream analysis will select all sample columns
 #' @param filter_plasmid_target_col default is NULL, and if NULL, will select the first column only; this parameter specifically should be used to specify the plasmid column(s) that will be selected
-#' @param filter_replicates_target_col default is NULL, Which sample columns are replicates whose variation you'd like to analyze; If NULL, the last 3 sample columns are used
+#' @param filter_replicates_target_col default is NULL, Which sample columns are the final time point replicates; If NULL, the last 3 sample columns are used. This is only used by this function to save a list of which pgRNA IDs have a zero count for all of these samples.
 #' @param cutoff default is NULL, relates to the low_plasmid_cpm filter; the cutoff for low log2 CPM values for the plasmid time period; if not specified, The lower outlier (defined by taking the difference of the lower quartile and 1.5 * interquartile range) is used
 #' @param min_n_filters default is 1; this parameter defines at least how many/the minimum number of independent filters have to flag a pgRNA construct before the construct is filtered when using a combination of filters
 #' You should decide on the appropriate filter based on the results of your QC report.
 #' @importFrom purrr reduce
 #' @returns a filtered version of the gimap_dataset returned in the $filtered_data section
+#'          filter_step_run is a boolean reporting if the filter step was run or not (since it's optional)
+#'          metadata_pg_ids is a subset the pgRNA IDs such that these are the ones that remain in the dataset following completion of filtering
+#'          transformed_log2_cpm is a subset the log2_cpm data such that these are the ones that remain in the dataset following completion of filtering
+#'          removed_pg_ids is a record of which pgRNAs are filtered out once filtering is complete
+#'          all_reps_zerocount_ids is not actually filtered data necessarily. Instead it's just a record of which pgRNAs have a zero count in all final timepoint replicates
 #' @export
 #' @examples \dontrun{
 #'

--- a/R/02-filter.R
+++ b/R/02-filter.R
@@ -106,7 +106,7 @@ gimap_filter <- function(.data = NULL,
                                                         filter(bool_vals == TRUE) %>% #drop rows where boolVals is false, so this leaves only filters that flagged a pgRNA for removal
                                                         select(id, filter_name) %>% #drop the boolVals column because don't need it anymore
                                                         group_by(id) %>% #group by the pgRNA constructs
-                                                        summarize(relevantFilters = toString(filterName)) #and make a column that comma separates the relevant filters
+                                                        summarize(relevantFilters = toString(filter_name)) #and make a column that comma separates the relevant filters
   
   ## save a list of which pgRNAs have a zero count in all final timepoint replicates. 
   #NOTE these are NOT necessarily filtered out

--- a/R/02-filter.R
+++ b/R/02-filter.R
@@ -101,7 +101,7 @@ gimap_filter <- function(.data = NULL,
   ## save a list of which pgRNAs are filtered out once filtering is complete
   gimap_dataset$filtered_data$removed_pg_ids <- cbind(gimap_dataset$metadata$pg_ids[combined_filter,], one_filter_df[combined_filter,]) %>% #add the IDs as a column together with the TRUEs and FALSEs for each filter, focusing only on pgRNAs which are in some way flagged for removal
                                                         pivot_longer(starts_with("Filter"), #pivot longer so that IDs are repeated and filter names are listed in a column and the last column (`boolVals`) are TRUEs and FALSEs
-                                                                     names_to = "filterName", 
+                                                                     names_to = "filter_name", 
                                                                      values_to = "boolVals") %>% 
                                                         filter(boolVals == TRUE) %>% #drop rows where boolVals is false, so this leaves only filters that flagged a pgRNA for removal
                                                         select(id, filterName) %>% #drop the boolVals column because don't need it anymore

--- a/R/02-filter.R
+++ b/R/02-filter.R
@@ -83,7 +83,7 @@ gimap_filter <- function(.data = NULL,
   #and finally compares the row sum to the `min_n_filters` parameter to report TRUEs and FALSEs according to whether each construct is flagged by the minimum number of required filters
   #TRUE means it should be filtered, FALSE means it shouldn't be filtered
   one_filter_df <- reduce(possible_filters, cbind) %>% 
-    `colnames<-`(c("FilterZeroCount", "FilterLowPlasmidCPM")) #*ADD any new filter's name here* as an additional column name; START with "Filter"
+    `colnames<-`(c("filter_zero_count", "filter_low_plasmi_cpm")) #*ADD any new filter's name here* as an additional column name; START with "Filter"
   combined_filter <- rowSums(one_filter_df) >= min_n_filters
   #within `combined_filter` TRUE means that the filtering steps flagged the pgRNA construct for removal, therefore, we'll want to use the opposite FALSE values for the filtered data, keeping those that weren't flagged by filtering steps
   

--- a/R/02-filter.R
+++ b/R/02-filter.R
@@ -110,6 +110,8 @@ gimap_filter <- function(.data = NULL,
   
   ## save a list of which pgRNAs have a zero count in all final timepoint replicates. 
   #NOTE these are NOT necessarily filtered out
+  if(is.null(filter_replicates_target_col)){ filter_replicates_target_col <- c((ncol(gimap_dataset$transformed_data$log2_cpm)-2) : ncol(gimap_dataset$transformed_data$log2_cpm))} #last 3 columns of the data
+  
   gimap_dataset$filtered_data$all_reps_zerocount_ids <- gimap_dataset$metadata$pg_ids[unlist(
                                                                                               gimap_dataset$raw_counts[,filter_replicates_target_col] %>% #grab the data from the final timepoint replicate columns
                                                                                                as.data.frame() %>%

--- a/R/03-annotate.R
+++ b/R/03-annotate.R
@@ -123,6 +123,12 @@ gimap_annotate <- function(.data = NULL,
     )))
 
   ################################ STORE IT ####################################
+  
+  if (gimap_dataset$filtered_data$filter_step_run){
+    keep_for_annotdf <- annotation_df$pgRNA_id %in% unlist(gimap_dataset$filtered_data$metadata_pg_ids)
+    annotation_df <- annotation_df[keep_for_annotdf,]
+  }
+  
   gimap_dataset$annotation <- annotation_df
 
   return(gimap_dataset)

--- a/R/plots-qc.R
+++ b/R/plots-qc.R
@@ -149,8 +149,8 @@ qc_constructs_countzero_bar <- function(gimap_dataset, filter_zerocount_target_c
                   values_to = "counts") %>%
       group_by(row) %>%
       summarize(numzero = sum(counts == 0),
-                max_diff = max(counts) - min(counts),
-                sec_diff = min(counts[counts > 0]) - min(counts)
+                max_diff = max(counts) - min(counts), #don't use this code outside of scratch visualizations
+                sec_diff = min(counts[counts > 0]) - min(counts) #don't use this code outside of scratch visualizations
                 ) %>%
       group_by(numzero) %>%
       summarize(count = n()) %>%
@@ -161,6 +161,8 @@ qc_constructs_countzero_bar <- function(gimap_dataset, filter_zerocount_target_c
       xlab("Number of replicates with a zero") +
       geom_text(aes(label = count, group = numzero), vjust = -0.5, size=2)
   )
+  
+  #would it be better to figure out how to record/output gimap_dataset$filtered_data$all_reps_zerocount_ids here?
 }
 
 #' Create a correlation heatmap for the pgRNA CPMs

--- a/R/plots-qc.R
+++ b/R/plots-qc.R
@@ -142,16 +142,13 @@ qc_constructs_countzero_bar <- function(gimap_dataset, filter_zerocount_target_c
   
 
   return(
-    example_counts[qc_filter_output$filter, filter_replicates_target_col] %>%
+    gimap_dataset$raw_counts[qc_filter_output$filter, filter_replicates_target_col] %>%
       as.data.frame() %>%
       mutate(row = row_number()) %>%
-      tidyr::pivot_longer(tidyr::unite(gimap_dataset$metadata$sample_metadata[filter_replicates_target_col, c("day", "rep")], "colName")$colName,
+      tidyr::pivot_longer(colnames(gimap_dataset$raw_counts)[filter_replicates_target_col],
                   values_to = "counts") %>%
       group_by(row) %>%
-      summarize(numzero = sum(counts == 0),
-                max_diff = max(counts) - min(counts), #don't use this code outside of scratch visualizations
-                sec_diff = min(counts[counts > 0]) - min(counts) #don't use this code outside of scratch visualizations
-                ) %>%
+      summarize(numzero = sum(counts == 0)) %>%
       group_by(numzero) %>%
       summarize(count = n()) %>%
       ggplot(aes(x=numzero, y = count)) +
@@ -161,8 +158,6 @@ qc_constructs_countzero_bar <- function(gimap_dataset, filter_zerocount_target_c
       xlab("Number of replicates with a zero") +
       geom_text(aes(label = count, group = numzero), vjust = -0.5, size=2)
   )
-  
-  #would it be better to figure out how to record/output gimap_dataset$filtered_data$all_reps_zerocount_ids here?
 }
 
 #' Create a correlation heatmap for the pgRNA CPMs

--- a/vignettes/getting_started.Rmd
+++ b/vignettes/getting_started.Rmd
@@ -148,7 +148,7 @@ There is a filter that flags pgRNA constructs where any of the time points have 
   - We include a table that specifies how many pgRNAs would be filtered out by applying this filter.
   
 There is a filter that flags pgRNA constructs that have low log2 CPM counts for the day 0 or plasmid time point. 
-  - The histogram of the log2 CPM values of pgRNA constructs at the plasmid time point mentioned earlier does have a dashed line specifying the lower outlier (or a user defined cutoff) and pgRNA constructs with a plasmid log2 CPM lower than that value can be filtered out. [TODO: Candace/Kate/Howard or is this being used as an argument in the code?]
+  - The histogram of the log2 CPM values of pgRNA constructs at the plasmid time point mentioned earlier does have a dashed line specifying the lower outlier (or a user defined cutoff) and pgRNA constructs with a plasmid log2 CPM lower than that value can be filtered out.
   - We include a table that specifies how many pgRNAs would be filtered out by applying this filter. 
 
 ```{r}
@@ -158,6 +158,8 @@ run_qc(gimap_dataset,
        quiet = TRUE)
 ```
 
+After considering the QC report and which filters are appropriate/desired for your data, you can apply filters to the data using the `gimap_filter` function.
+
 ```{r}
 gimap_dataset <- gimap_dataset %>% 
   gimap_filter()
@@ -165,6 +167,17 @@ gimap_dataset <- gimap_dataset %>%
 nrow(gimap_dataset$filtered_data$transformed_log2_cpm)
 
 ```
+
+By default, ...
+
+As you can see from the output above, there are fewer pgRNA constructs in the filtered dataset following completion of filtering. 
+
+The filtering step also stores two tables of information that you may want to use or report. 
+
+- `$filtered_data$removed_pg_ids` is a table that has the pgRNA construct IDs that are removed following completion of filtering in the `id` column and the relevant filter(s) that led to removal as a comma separated list in the `relevantFilters` column
+- `$filtered_data$all_reps_zerocount_ids` is a table that lists the IDs of pgRNA constructs which had a count of 0 for all final timepoint replicates. These pgRNA constructs are NOT necessarily filtered out
+
+To view or output these tables....
 
 ```{r}
 sessionInfo()


### PR DESCRIPTION
This records the two tables that were requested in the meeting yesterday (copied from the meeting notes):
(1) 0 counts in all three replicates (whether filtered out or not)
(2) what’s filtered out/why

I've got the 1st saved in the `$filtered_data$all_reps_zerocount_ids` and have noted that those IDs are NOT necessarily filtered throughout the documentation

I've got the 2nd saved in the `$filtered_data$removed_pg_ids` and it's a table with the ids in the first column and a comma separated list of which filters were relevant for its removal in the second column. Was hoping that this approach would be human readable especially since I wouldn't have to explain what a TRUE or FALSE meant 

Added a bit of description of these in the vignette. 