### PR TITLE
Specify fastmap version in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,8 +34,9 @@ Imports:
     janitor,
     broom,
     utils,
-    stats, 
-    stringr
+    stats,
+    stringr,
+    fastmap (>= 1.2.0)
 Suggests:
     testthat (>= 3.0.0),
     roxygen2,


### PR DESCRIPTION
# Description

Due to the issue observed when testing new data from Sita, needed to specify the version of fastmap in the DESCRIPTION file to be a specific min version. Used  the `usethis` package, specifically `use_package("fastmap", min_version = "1.2.0")` to append this to the imports section of the DESCRIPTION file.  

Fixes #54 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

In the branch with this change, I used `devtools::load_all()` and ran the `.Rmd` where I originally observed the error and it ran without error, producing an output report this time.

